### PR TITLE
Fix data binding check

### DIFF
--- a/src/plots/command.js
+++ b/src/plots/command.js
@@ -41,9 +41,9 @@ exports.manageCommandObserver = function(gd, container, commandList, onchange) {
     }
 
     // Either create or just recompute this:
-    ret.lookupTable = {};
+    ret.bindingsByValue = {};
 
-    var binding = exports.hasSimpleAPICommandBindings(gd, commandList, ret.lookupTable);
+    var binding = exports.hasSimpleAPICommandBindings(gd, commandList, ret.bindingsByValue);
 
     if(container && container._commandObserver) {
         if(!binding) {
@@ -78,14 +78,14 @@ exports.manageCommandObserver = function(gd, container, commandList, onchange) {
             if(update.changed && onchange) {
                 // Disable checks for the duration of this command in order to avoid
                 // infinite loops:
-                if(ret.lookupTable[update.value] !== undefined) {
+                if(ret.bindingsByValue[update.value] !== undefined) {
                     ret.disable();
                     Promise.resolve(onchange({
                         value: update.value,
                         type: binding.type,
                         prop: binding.prop,
                         traces: binding.traces,
-                        index: ret.lookupTable[update.value]
+                        index: ret.bindingsByValue[update.value]
                     })).then(ret.enable, ret.enable);
                 }
             }
@@ -116,7 +116,7 @@ exports.manageCommandObserver = function(gd, container, commandList, onchange) {
         // is a start
         Lib.warn('Unable to automatically bind plot updates to API command');
 
-        ret.lookupTable = {};
+        ret.bindingsByValue = {};
         ret.remove = function() {};
     }
 

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -155,17 +155,12 @@ describe('Plots.hasSimpleAPICommandBindings', function() {
             args: [{'marker.color': 20}, [2, 1]]
         }]);
 
-        // See https://github.com/plotly/plotly.js/issues/1169 for an example of where
-        // this logic was a little too sophisticated. It's better to bail out and omit
-        // functionality than to get it wrong.
-        expect(isSimple).toEqual(false);
-
-        /* expect(isSimple).toEqual({
+        expect(isSimple).toEqual({
             type: 'data',
             prop: 'marker.color',
             traces: [ 1, 2 ],
             value: [ 10, 10 ]
-        });*/
+        });
     });
 });
 


### PR DESCRIPTION
@rreusser @etpinard 

This fix changes the signature of `exports.hasSimpleAPICommandBindings = function(gd, commandList, bindingsByValue, valueByBindings)` in a backwards-compatible way (I don't really like the new signature; if compatibility isn't an issue here, I'd pass `binding` instead of `bindingsByValue` and `valueByBindings`).

This change in signature was introduced so that I could search for bindings when the associated value is an array.